### PR TITLE
Wait for BayeuxClient disconnect to complete before stopping HTTPClient

### DIFF
--- a/src/main/java/com/genesys/statistics/Notifications.java
+++ b/src/main/java/com/genesys/statistics/Notifications.java
@@ -131,14 +131,19 @@ public class Notifications
 			throw new StatisticsException("Initialization failed.", ex);
 		}
 	}
+    
+    public void disconnect() throws StatisticsException
+	{
+		disconnect(10000); // 10 second timeout by default
+	}
 
-	public void disconnect() throws StatisticsException
+	public void disconnect(long disconnectRequestTimeout) throws StatisticsException
 	{
 		try
 		{
 			if (client != null)
 			{
-				client.disconnect();
+				client.disconnect(disconnectRequestTimeout);
 			}
 			if (httpClient != null)
 			{

--- a/src/main/java/com/genesys/statistics/Statistics.java
+++ b/src/main/java/com/genesys/statistics/Statistics.java
@@ -443,6 +443,11 @@ public class Statistics
 	{
 		notifications.disconnect();
 	}
+    
+    public void destroy(long disconnectRequestTimeout) throws StatisticsException
+	{
+		notifications.disconnect(disconnectRequestTimeout);
+	}
 
 	public interface StatisticsListener
 	{


### PR DESCRIPTION
Updated to call BayeuxClient.disconnect(long) during API disconnect to prevent sockets getting stuck in CLOSE_WAIT state